### PR TITLE
Fix for the problem where a valid `GNTP/1.0 -OK' response is not processed correctly

### DIFF
--- a/lib/Growl/GNTP.pm
+++ b/lib/Growl/GNTP.pm
@@ -84,7 +84,7 @@ EOF
     $sock->send($form);
 
     my $ret = <$sock>;
-    $ret = $1 if $ret =~ /^GNTP\/1.0 (-?\w+).*$/;
+    $ret = $1 if $ret =~ /^GNTP\/1\.0 -?(\w+).*$/;
     print "$_\n" if $self->{Debug};
 
     my $description = 'failed to register';
@@ -164,7 +164,7 @@ sub notify {
     $sock->send($form);
 
     my $ret = <$sock>;
-    $ret = $1 if $ret =~ /^GNTP\/1.0 (-?\w+).*$/;
+    $ret = $1 if $ret =~ /^GNTP\/1\.0 -?(\w+).*$/;
     print "$_\n" if $self->{Debug};
 
     my $description = 'failed to notify';
@@ -213,7 +213,7 @@ EOF
     $sock->send($form);
 
     my $ret = <$sock>;
-    $ret = $1 if $ret =~ /^GNTP\/1.0 (-?\w+).*$/;
+    $ret = $1 if $ret =~ /^GNTP\/1\.0 -?(\w+).*$/;
     print "$_\n" if $self->{Debug};
 
     my $description = 'failed to register';
@@ -241,7 +241,7 @@ EOF
         while (<$client>){
             $_ =~ s!\r\n!!g;
             print "$_\n" if $self->{Debug};
-            $ret     = $1 if $_ =~ /^GNTP\/1.0 (\w+).*/;
+            $ret     = $1 if $_ =~ /^GNTP\/1\.0 -?(\w+).*/;
             $description  = $1 if $_ =~ /^Error-Description:\s*(.*)$/;
             $Title   = $1 if $_ =~ /^Notification-Title: (.*)\r\n/;
             $Message = $1 if $_ =~ /^Notification-Text: (.*)\r\n/;


### PR DESCRIPTION
Running the test with Growl::GNTP 0.08 and Growl For Linux **0.2**:

<pre>
% perl -Ilib t/01_simple.t
1..1
failed to register at lib/Growl/GNTP.pm line 101.
# Looks like your test exited with 255 before it could output anything.
</pre>


Hope this quick fix helps.
